### PR TITLE
add ephemeral role and helpers

### DIFF
--- a/commands/helpers/role.js
+++ b/commands/helpers/role.js
@@ -1,0 +1,26 @@
+const rolesFile = require('../../scripts/roles.js');
+
+module.exports = {
+    autocomplete: async function autocomplete(interaction) {
+      const focusedValue = interaction.options.getFocused();
+      filtered = rolesFile.getFilteredRoleNames(focusedValue).splice(0,25)
+
+      await interaction.respond(
+          filtered.map(choice => ({ name: choice, value: choice })),
+      );
+  },
+
+    execute: async function execute(interaction, ephemeral=false) {
+      const roleName = interaction.options.getString('name') ?? "error";
+
+      role = rolesFile.roleCheck(roleName);
+
+      if (role != null) {
+          const embed = await rolesFile.getRoleEmbed(role);
+          await interaction.reply({ ephemeral: ephemeral, embeds: [ embed ] });
+
+      } else {
+        await interaction.reply({content:`The role: ${roleName} was not found`, ephemeral: true});
+      }
+    }
+}

--- a/commands/roleSecret.js
+++ b/commands/roleSecret.js
@@ -3,20 +3,20 @@ const helper = require('./helpers/role.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName("role")
-    .setDescription("Provides information about the named role.")
+    .setName("rolesecret")
+    .setDescription("Secretly provides information about the named role.")
     .addStringOption(option =>
 		option.setName('name')
 			.setDescription('The role you are looking for')
             .setRequired(true)
             .setAutocomplete(true)),
 
-    async autocomplete(interaction) {
-      helper.autocomplete(interaction)
-    },
+  async autocomplete(interaction) {
+    helper.autocomplete(interaction)
+  },
 
 
-    async execute(interaction) {
-      helper.execute(interaction)
-    }
+  async execute(interaction) {
+    helper.execute(interaction, ephemeral=true)
+  }
 };


### PR DESCRIPTION
add /rolesecret that only tells you what the role does

code for /role and /rolesecret moved into commands/helpers/role.js because they share identical code bases